### PR TITLE
Rebuild to include Intel OSX Python 3.13

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 35ccfed3926a36b030d9b919e3f7e5b6ed9b0820f878b5a6d9a2b740c3c896c2
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<310]
   ignore_run_exports_from:
     - libclang
@@ -48,12 +48,11 @@ test:
   requires:
     - pip
     - pytest
-    # Temporarily disable tests on intel osx py313 due to missing pytensor build
-    - pymc-base >=5.21  # [arm64 or not (py==313 and osx)]
+    - pymc-base >=5.21
     - numba >=0.60
   commands:
     - pip check
-    - pytest tests/test_pymc.py -k "not jax" -m "not flow"  # [arm64 or not (osx and py==313)]
+    - pytest tests/test_pymc.py -k "not jax" -m "not flow"
   source_files:
     - tests
 


### PR DESCRIPTION
This might need to be restarted until the new PyTensor build started in https://github.com/conda-forge/pytensor-suite-feedstock/pull/145 hits the CDN.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
